### PR TITLE
Fix problem with recent Starcounter XSON

### DIFF
--- a/juicy-select.html
+++ b/juicy-select.html
@@ -42,17 +42,25 @@ version: 1.0.0
                 this.$select.addEventListener("change", this.selectChange.bind(this));
                 this.set("multiple", this.$select.hasAttribute("multiple"));
 
+                this.isAttached = true;
+
                 setTimeout(function () {
+                    if (!this.isAttached)
+                        return;
+
                     this.generateOptions();
-                    this.isAttached = true;
+                    this.isInitialized = true;
 
                     if (this.value != this.$select.value && !this.multiple) {
                         this.set("value", this.$select.value);
                     }
                 }.bind(this), 10);
             },
+            detached: function () {
+                this.isAttached = false;
+            },
             optionsChanged: function () {
-                if (this.isAttached) {
+                if (this.isInitialized) {
                     this.generateOptions();
                 }
             },

--- a/juicy-select.html
+++ b/juicy-select.html
@@ -42,12 +42,7 @@ version: 1.0.0
                 this.$select.addEventListener("change", this.selectChange.bind(this));
                 this.set("multiple", this.$select.hasAttribute("multiple"));
 
-                this.isAttached = true;
-
-                setTimeout(function () {
-                    if (!this.isAttached)
-                        return;
-
+                this._initializationTimeout = setTimeout(function () {
                     this.generateOptions();
                     this.isInitialized = true;
 
@@ -57,7 +52,7 @@ version: 1.0.0
                 }.bind(this), 10);
             },
             detached: function () {
-                this.isAttached = false;
+                clearTimeout(this._initializationTimeout);
             },
             optionsChanged: function () {
                 if (this.isInitialized) {


### PR DESCRIPTION
Recent versions of Starcounter XSON does not allow `Add` operations in JSON Patch sent from client side.

When `<juicy-select>` is dynamically inserted in a DOM based on view model structure, and the structure changes rapidly, the view model may change so that the element may be ripped out of the DOM before the `setTimeout()` on line 47 times out. When `value` is set on line 55, the view model property bound to the `value` attribute no longer exists in the view model, which triggers a JSON Patch to be sent to the server with an `Add` operation. Fail!

The proposed change protects the code in `setTimeout()` by ensuring that he element is still attached before doing anything potentially bad.