### PR TITLE
Use correct observation logic for options

### DIFF
--- a/issue-5-demo.html
+++ b/issue-5-demo.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>juicy-select</title>
+	<meta charset="utf-8" />
+    <script type="text/javascript" src="../webcomponentsjs/webcomponents-lite.js"></script>
+    <link rel="import" href="../polymer/polymer.html" />
+    <link rel="import" href="juicy-select.html" />
+</head>
+<body>
+    <dom-bind>
+        <template>
+            <div class="horizontal-section">
+                <div>Select countries you have visited:</div>
+                <juicy-select multiple="true" options="{{model.Countries}}" selected-property="Selected" text-property="Name" value-property="Name"></juicy-select>
+           </div>          
+        </template>
+        
+    </dom-bind>
+    <script>
+        var template = document.querySelector('dom-bind');
+           
+        template.set('model', {
+            Countries: [{ Name: "Sweden", Selected: false }, { Name: "China", Selected: false }, { Name: "India", Selected: false }],
+            FavoriteCountry: "",
+            LazyOptions: []
+        });
+      
+        setTimeout(() => {              
+          template.set('model.Countries', [{ Name: "Poland", Selected: false }, { Name: "China", Selected: false }, { Name: "India", Selected: false }]);
+        }, 1000);
+      
+       setTimeout(() => { 
+
+         template.model.Countries.push({ Name: "Peru", Selected: false });
+
+         template.notifySplices('model.Countries', [{
+           index: 3,
+           removed: [],
+           addedCount: 1,
+           object: template.model.Countries,
+           type: 'splice'
+         }])
+        }, 2000);      
+        
+      
+      
+    </script>
+</body>
+</html>

--- a/juicy-select.html
+++ b/juicy-select.html
@@ -19,7 +19,7 @@ version: 1.1.0
         Polymer({
             is: "juicy-select",
             properties: {
-                options: { type: Array, value: [], observer: "optionsChanged" },
+                options: { type: Array, value: [], notify: true },
                 multiple: { type: Boolean, value: false },
                 value: { type: String, notify: true, observer: "valueChanged" },
                 selectedProperty: { type: String, observer: "optionsChanged" },
@@ -27,6 +27,7 @@ version: 1.1.0
                 valueProperty: { type: String, observer: "optionsChanged" },
                 captionText: { type: String, observer: "optionsChanged" }
             },
+            observers: ['optionsChanged(options.*)'],
             created: function () {
                 this.selectChange = this.selectChange.bind(this);
             },


### PR DESCRIPTION
I added the logic @aloscha advised and it does indeed fix an existing issue. I created `issue-5-demo.html` to show a demo. And I can confirm it didn't work properly before it.

If you'd like to test it, please pull this branch, polyserve, and navigate to `issue-5-demo.html` locally, then remove line 30 and undo line 22 as it was. The demo should break.

