### PR TITLE
Use option.innerText instead of option.innerHTML to prevent HTML injection attacks

### DIFF
--- a/juicy-select.html
+++ b/juicy-select.html
@@ -83,7 +83,7 @@ version: 1.1.3
                     var row = this.options[i];
                     var opt = document.createElement("option");
 
-                    opt.innerHTML = row[this.textProperty];
+                    opt.innerText = row[this.textProperty];
                     opt.value = row[this.valueProperty];
 
                     if (this.multiple) {


### PR DESCRIPTION
When using `innerHTML` an option with text like `<META HTTP-EQUIV='Refresh' content ='0; URL=something bad'>` would cause page redirect to `something bad`.